### PR TITLE
Fix memory issues

### DIFF
--- a/src/simple-delay.c
+++ b/src/simple-delay.c
@@ -7,8 +7,8 @@
 
 void delay_process(float *input_buffer, uint32_t input_length, uint32_t delay_time, float delay_feedback, float delay_spread, uint8_t delay_direction, float delay_volume)
 {
-	float *delay_buffer     = (float*)malloc(delay_time * 2 * sizeof(float)); // x2 because stereo
-	float *input_buffer_wet = (float*)malloc(input_length   * sizeof(float));
+	float *delay_buffer     = (float*)calloc(delay_time * 2, sizeof(float)); // x2 because stereo
+	float *input_buffer_wet = (float*)calloc(input_length, sizeof(float));
 
 	uint32_t delay_playhead = 1;
 

--- a/src/super-wavexe.c
+++ b/src/super-wavexe.c
@@ -154,9 +154,9 @@ int main()
 	trig_tables_init();
 
 	// where we'll put the final mix, individual voice, and wavecycle data
-	float *buffer_float   = (float*)malloc(TOTAL_SAMPLES  * sizeof(float));
-	float *voice_buffer   = (float*)malloc(TOTAL_SAMPLES  * sizeof(float));
-	float *wavecycle_data = (float*)malloc(WAVECYCLE_SIZE * (TOTAL_WAVECYCLES + 1) * sizeof(float));
+	float *buffer_float   = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+	float *voice_buffer   = (float*)calloc(TOTAL_SAMPLES,  sizeof(float));
+	float *wavecycle_data = (float*)calloc(WAVECYCLE_SIZE * (TOTAL_WAVECYCLES + 1), sizeof(float));
 
 	#ifdef DEBUG
 		printf("Building wavecycles...\n");
@@ -165,7 +165,7 @@ int main()
 	generate_wavecycles(wavecycle_data);
 
 	// where we'll put drum data
-	float *drum_data = (float*)malloc(TOTAL_DRUM_DATA_SIZE * sizeof(float));
+	float *drum_data = (float*)calloc(TOTAL_DRUM_DATA_SIZE, sizeof(float));
 
 	#ifdef DEBUG
 		printf("Building drums...\n");
@@ -175,7 +175,7 @@ int main()
 
 	// fx variables
 	uint16_t fx_timer;
-	uint8_t  fx_update_flag [TOTAL_VOICES];
+	uint8_t  fx_update_flag [TOTAL_VOICES] = { 0 };
 
 	#ifdef DEBUG
 		uint32_t debug_song_buffer_size    = TOTAL_SAMPLES  * sizeof(float);
@@ -231,7 +231,7 @@ int main()
 		// stereo offset variables
 		float tan_smoothing_l = 0.0;
 		float tan_smoothing_r = 0.0;
-		uint8_t stereo_fx_counter;
+		uint8_t stereo_fx_counter = 0;
 
 		// initial parameters
 		configure_instrument(0);
@@ -519,7 +519,7 @@ int main()
 	#endif
 
 	// final output array
-	int16_t *buffer_int = (int16_t*)malloc(TOTAL_SAMPLES * sizeof(int16_t));
+	int16_t *buffer_int = (int16_t*)calloc(TOTAL_SAMPLES, sizeof(int16_t));
 	float_to_sixteen_bit(buffer_float, buffer_int, TOTAL_SAMPLES);
 
 	// we'll miss you buffer float

--- a/src/wave-data.h
+++ b/src/wave-data.h
@@ -263,4 +263,6 @@ void generate_wavecycles(float *input_wavecycle_array)
 		for (uint16_t w = 0; w < zero_crossing_offset; w++)
 			input_wavecycle_array[(w + zero_crossing_offset) + WAVECYCLE_SIZE * i] = wave_data[w];
 	}
+
+	free(wave_data);
 }

--- a/src/wave-export.c
+++ b/src/wave-export.c
@@ -95,6 +95,8 @@ void wave_export(int16_t *input_buffer, uint32_t input_length)
 	#ifdef DEBUG
 		printf("Successfully written! (Maybe, there's no error checking.)\n");
 	#endif
+
+	fclose(output_wave_file);
 }
 
 #define DITHER_GAIN  5  // volume of dither noise


### PR DESCRIPTION
Hi!

First of all, thank you for your work on this. It's a really cool project. :D

While running the program on Linux, I noticed that super-wavexe would sometimes, seemingly at random, generate some garbled audio output in `output.wav` (had to upload to vocaroo because Github doesn't support `.wav` files): https://vocaroo.com/1Zisg1Z7aAiS. This pull requests fixes that issue, as well as a couple memory leaks found using a memory sanitizer. :)

In case you're interested in taking a look at it yourself, I basically compiled the program with `-g3` (verbose debug symbols) and ran the program through [valgrind](https://valgrind.org/), which allows us to investigate memory bugs:

```
$ valgrind --leak-check=full \
         --show-leak-kinds=all \
         --track-origins=yes \
         --verbose \
         ./src/super-wavexe
```

Sure enough, there were a bunch of memory errors such as these:

```
...
==51179== 2128392 errors in context 15 of 141:
==51179== Conditional jump or move depends on uninitialised value(s)
==51179==    at 0x10961D: foldback (handy-functions.h:22)
==51179==    by 0x10961D: main (super-wavexe.c:267)
==51179==  Uninitialised value was created by a heap allocation
==51179==    at 0x4841848: malloc (vg_replace_malloc.c:431)
==51179==    by 0x1091C3: main (super-wavexe.c:159)
...
```

Most of them stemmed from reading garbage from uninitialized buffers that were `malloc`'d (`malloc` always returns uninitialized memory!), so I fixed them by using `calloc` (which returns zero-initialized memory). While I was at it I also fixed a couple of unreleased memory issues. Running the program through `valgrind` no longer reports any memory errors. :)